### PR TITLE
改进模型更新条件获取

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -708,13 +708,13 @@ abstract class Model implements JsonSerializable, ArrayAccess, Arrayable, Jsonab
     {
         $pk = $this->getPk();
 
-        if (is_string($pk) && isset($this->data[$pk])) {
-            $where     = [[$pk, '=', $this->data[$pk]]];
-            $this->key = $this->data[$pk];
+        if (is_string($pk) && isset($this->origin[$pk])) {
+            $where     = [[$pk, '=', $this->origin[$pk]]];
+            $this->key = $this->origin[$pk];
         } elseif (is_array($pk)) {
             foreach ($pk as $field) {
-                if (isset($this->data[$field])) {
-                    $where[] = [$field, '=', $this->data[$field]];
+                if (isset($this->origin[$field])) {
+                    $where[] = [$field, '=', $this->origin[$field]];
                 }
             }
         }


### PR DESCRIPTION
根据 #104 的问题做了一个修正，更新条件改用模型原始数据``$this->origin``来获取，避免主键数值被修改后更新条件获取不正确的问题。